### PR TITLE
Fix button taking precedence over submit button

### DIFF
--- a/admin/content-popup-button.php
+++ b/admin/content-popup-button.php
@@ -3,7 +3,7 @@
 defined( 'ABSPATH' ) or die();
 ?>
 
-<button data-opinionstage-content-launch class="button">
+<button data-opinionstage-content-launch class="button" type="button">
 <img src="<?php echo plugins_url('admin/images/content-popup.png', plugin_dir_path( __FILE__ )) ?>"
 		width="24"
 		height="19"


### PR DESCRIPTION
When no type is set, a button defaults to `type="submit"` causing the OpinionStage widget to open instead of the post saving when pressing <kbd>enter</kbd> in a textfield (for example the title field). Setting it to `type="button"` fixes that.

Ref: https://stackoverflow.com/a/12914700/1580028